### PR TITLE
Replace displays-available callback with a synchroneous, blocking method.

### DIFF
--- a/src/PinMame.Example/Example.cs
+++ b/src/PinMame.Example/Example.cs
@@ -190,12 +190,6 @@ namespace PinMame
 			Logger.Info($"OnGameStarted");
 		}
 
-		static void OnDisplaysAvailable(object sender, EventArgs e, Dictionary<int, PinMameDisplayLayout> displayLayouts)
-		{
-			var str = string.Join("\n", displayLayouts.Keys.Select(t => $"{t}: {displayLayouts[t]}"));
-			Logger.Info($"OnDisplaysAvailable ({displayLayouts.Count}): displays={str}");
-		}
-
 		static void OnDisplayAvailable(object sender, EventArgs e, int index, int displayCount, PinMameDisplayLayout displayLayout)
 		{
 			Logger.Info($"OnDisplayAvailable: index={index}, displayCount={displayCount}, displayLayout={displayLayout}");
@@ -244,7 +238,6 @@ namespace PinMame
 
 			_pinMame.OnGameStarted += OnGameStarted;
 			_pinMame.OnDisplayAvailable += OnDisplayAvailable;
-			_pinMame.OnDisplaysAvailable += OnDisplaysAvailable;
 			_pinMame.OnDisplayUpdated += OnDisplayUpdated;
 			_pinMame.OnSolenoidUpdated += OnSolenoidUpdated;
 			_pinMame.OnGameEnded += OnGameEnded;

--- a/src/PinMame.Example/Example.cs
+++ b/src/PinMame.Example/Example.cs
@@ -31,10 +31,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using NLog;
-using Logger = NLog.Logger;
+using NLog.Config;
+using NLog.Targets;
 
 namespace PinMame
 {
@@ -223,9 +223,9 @@ namespace PinMame
 
 		static void Main(string[] args)
 		{
-			LogManager.Configuration = new NLog.Config.LoggingConfiguration();
+			LogManager.Configuration = new LoggingConfiguration();
 
-			var target = new NLog.Targets.ConsoleTarget("PinMame");
+			var target = new ConsoleTarget("PinMame");
 
 			LogManager.Configuration.AddTarget(target);
 			LogManager.Configuration.AddRule(LogLevel.Info, LogLevel.Fatal, target);


### PR DESCRIPTION
In #15, a new callback was introduced. The problem with it was that the callback would be executed either on the waiting thread or on the PinMAME thread, which made dealing with it difficult (for once, we can't seem to `.StopGame()` on the PinMAME thread itself).

So this is a simpler approach: Block until everything's done or timed out, then return on the same thread we were launched on. It only takes a few milliseconds anyways.