### PR TITLE
Fix native interop threading and callback ABI

### DIFF
--- a/src/PinMame/PinMame.cs
+++ b/src/PinMame/PinMame.cs
@@ -190,6 +190,12 @@ namespace PinMame
 		public static int RunState => PinMameApi.IsRunning();
 
 		/// <summary>
+		/// Sets a time fence where emulation is suspended when reached until the fence moves forward.
+		/// </summary>
+		/// <param name="timeInS">Absolute fence time in seconds.</param>
+		public static void SetTimeFence(double timeInS) => PinMameApi.SetTimeFence(timeInS);
+
+		/// <summary>
 		/// Returns the hardware generation
 		/// </summary>
 		/// <returns>Value of the hardware generation</returns>

--- a/src/PinMame/PinMameApi.cs
+++ b/src/PinMame/PinMameApi.cs
@@ -726,19 +726,34 @@ namespace PinMame
 
 		#region Delegates
 
-		internal delegate void GameCallback(IntPtr gamePtr);
-		internal delegate void OnStateUpdatedCallback(int change);
-		internal delegate void OnDisplayAvailableCallback(int index, int displayCount, ref DisplayLayout displayLayout);
-		internal delegate void OnDisplayUpdatedCallback(int index, IntPtr framePtr, ref DisplayLayout displayLayout);
-		internal delegate int OnAudioAvailableCallback(ref AudioInfo audioInfo);
-		internal delegate int OnAudioUpdatedCallback(IntPtr bufferPtr, int samples);
-		internal delegate void OnMechAvailableCallback(int mechNo, ref MechInfo mechInfo);
-		internal delegate void OnMechUpdatedCallback(int mechNo, ref MechInfo mechInfo);
-		internal delegate void OnSolenoidUpdatedCallback(int solenoid, int isActive);
-		internal delegate void OnConsoleDataUpdatedCallback(IntPtr dataPtr, int size);
-		internal delegate int IsKeyPressedFunction(Keycode keycode);
-		internal delegate void OnLogMessageCallback(LogLevel logLevel, string format, string args);
-		internal delegate void OnSoundCommandCallback(int boardNo, int cmd);
+		// NOTE: LibPinMAME callback ABI (Windows): __stdcall and includes a trailing userData pointer.
+		// See pinmame/src/libpinmame/libpinmame.h (PINMAMECALLBACK).
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void GameCallback(IntPtr gamePtr, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void OnStateUpdatedCallback(int change, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void OnDisplayAvailableCallback(int index, int displayCount, ref DisplayLayout displayLayout, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void OnDisplayUpdatedCallback(int index, IntPtr framePtr, ref DisplayLayout displayLayout, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate int OnAudioAvailableCallback(ref AudioInfo audioInfo, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate int OnAudioUpdatedCallback(IntPtr bufferPtr, int samples, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void OnMechAvailableCallback(int mechNo, ref MechInfo mechInfo, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void OnMechUpdatedCallback(int mechNo, ref MechInfo mechInfo, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void OnSolenoidUpdatedCallback(ref SolenoidState solenoidState, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void OnConsoleDataUpdatedCallback(IntPtr dataPtr, int size, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate int IsKeyPressedFunction(Keycode keycode, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void OnLogMessageCallback(LogLevel logLevel, string format, IntPtr args, IntPtr userData);
+		[UnmanagedFunctionPointer(CallingConvention.StdCall)]
+		internal delegate void OnSoundCommandCallback(int boardNo, int cmd, IntPtr userData);
 
 		#endregion
 
@@ -777,10 +792,10 @@ namespace PinMame
 
 		#region Game library functions
 		[DllImport(Libraries.PinMame, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PinmameGetGame")]
-		internal static extern Status GetGame(string name, GameCallback callback);
+		internal static extern Status GetGame(string name, GameCallback callback, IntPtr userData);
 
 		[DllImport(Libraries.PinMame, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PinmameGetGames")]
-		internal static extern Status GetGames(GameCallback callback);
+		internal static extern Status GetGames(GameCallback callback, IntPtr userData);
 		#endregion
 
 		#region Options related functions


### PR DESCRIPTION
- **Fix callback ABI mismatch**: All P/Invoke delegates are now decorated with
    `[UnmanagedFunctionPointer(CallingConvention.StdCall)]` and include the trailing
    `IntPtr userData` parameter to match the `PINMAMECALLBACK` ABI defined in
    `libpinmame.h`. This was the root cause of crashes and undefined behavior on Windows.
- **Fix solenoid callback signature**: `OnSolenoidUpdatedCallback` now receives a
    `ref SolenoidState` struct instead of two separate `int` parameters, matching the
    updated native signature.
- **Improve `Stop()` robustness**: `Stop()` now polls until the run state confirms
    the emulator has actually stopped, retrying for up to 5 seconds with logging on
    each attempt, rather than fire-and-forget.
- **Add exception guards in callbacks**: `OnDisplayUpdated`, `OnAudioUpdated`, and
    `OnSolenoidUpdated` now catch and log exceptions so a callback failure can't unwind
    into native code.
- **Log native library path on load**: `LibraryResolver` now logs the resolved path
    and handle of the native DLL once at startup, making it easier to diagnose
    wrong-DLL-loaded issues.
- **Expose `SetTimeFence()`**: The existing internal `PinMameApi.SetTimeFence()` is
    now accessible as a public static method on `PinMame`.